### PR TITLE
update dependencies and bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jsx-coverage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Enable coverage on .JSX or .coffee files.",
   "author": "Zordius <zordius@yahoo-inc.com>",
   "contributors": [
@@ -32,16 +32,16 @@
   "dependencies": {
     "parse-base64vlq-mappings": "0.1.4",
     "object.assign": "1.1.1",
-    "babel": "4.0.1",
-    "gulp": "3.8.10",
-    "istanbul": "0.3.5",
+    "babel": "4.7.0",
+    "gulp": "3.8.11",
+    "istanbul": "0.3.7",
     "gulp-mocha": "2.0.0"
   },
   "devDependencies": {
-    "mocha": "2.0.1",
-    "coffee-script": "1.8.0",
+    "mocha": "2.1.0",
+    "coffee-script": "1.9.1",
     "react": "0.12.2",
-    "jsdom": "2.0.0"
+    "jsdom": "3.1.2"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Hey Again,

I've just upgraded the dependencies to the latest versions (except JSDOM, which is on version 4.x.x, which only supports IO.js. I upgraded it to the latest version that supports Node, which is 3.x.x).

I've also bumped the version number of the npm package to 0.1.1, so you can just npm publish :).
