### PR TITLE
allow minor version changes for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "parse-base64vlq-mappings": "0.1.4",
     "object.assign": "1.1.1",
     "babel": "^5.0.0",
-    "gulp": "3.9.0",
-    "gulp-util": "3.0.6",
-    "istanbul": "0.3.7",
-    "gulp-mocha": "2.0.0"
+    "gulp": "^3.9.0",
+    "gulp-util": "^3.0.6",
+    "istanbul": "^0.3.7",
+    "gulp-mocha": "^2.0.0"
   },
   "devDependencies": {
     "gulp-jasmine": "2.0.1",


### PR DESCRIPTION
We were running into issues with `gulp-mocha` since it was locked into `2.0.0`.  Ideally these dependencies should allow any non-breaking (minor) changes.
