### PR TITLE
check existence of sourcesContent[0]

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ addSourceComments = function (source, sourceMap) {
         line,
         outputs = [];
 
-    if (sourceMap && sourceMap.sourcesContent) {
+    if (sourceMap && sourceMap.sourcesContent && sourceMap.sourcesContent[0]) {
         sourceMap.newLines = lines.slice(0);
         oldlines = sourceMap.sourcesContent[0].split(/\n/);
         parseVLQ(sourceMap.mappings).forEach(function (P) {


### PR DESCRIPTION
When blank file is included, a test will always failed. I think it should succeed with `0 passing`.

```
events.js:141
      throw er; // Unhandled 'error' event
      ^
TypeError: Cannot read property 'split' of undefined
    at addSourceComments (/path/to/project/node_modules/gulp-jsx-coverage/index.js:46:47)
    at Object.moduleLoader [as .js] (/path/to/project/node_modules/gulp-jsx-coverage/index.js:126:39)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at /path/to/project/node_modules/mocha/lib/mocha.js:192:27
    at Array.forEach (native)
    at Mocha.loadFiles (/path/to/project/node_modules/mocha/lib/mocha.js:189:14)
    at Mocha.run (/path/to/project/node_modules/mocha/lib/mocha.js:422:31)
```

```
{ version: 3,
  sources: [],
  names: [],
  mappings: '',
  file: '/path/to/project/tests/blank_file.js',
  sourcesContent: [] }
```
