### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+node_modules
+artifacts
+coverage
+
+test
+gulpfile.js
+
+*.png


### PR DESCRIPTION
I noticed after installing this package that it still included files like `demo1.png`, test files, etc.

I've added an `.npmignore` file to exclude these from your published package.
